### PR TITLE
Updated karma.conf.js to run with karma 0.10.2

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,73 +1,72 @@
 // Karma configuration
-// Generated on Sun Mar 31 2013 21:59:25 GMT+0200 (CEST)
+// Generated on Sun Oct 20 2013 07:28:56 GMT+0200 (CEST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path, that will be used to resolve files and exclude
+    basePath: '',
 
 
-// base path, that will be used to resolve files and exclude
-basePath = '';
+    // frameworks to use
+    frameworks: ['jasmine', 'requirejs'],
 
 
-// list of files / patterns to load in the browser
-files = [
-  JASMINE,
-  JASMINE_ADAPTER,
-  REQUIRE,
-  REQUIRE_ADAPTER,
+    // list of files / patterns to load in the browser
+    files: [
+        {pattern: 'lib/**/*.js', included: false},
+        {pattern: 'src/**/*.js', included: false},
+        {pattern: 'test/**/*Spec.js', included: false},
 
-  {pattern: 'lib/**/*.js', included: false},
-  {pattern: 'src/**/*.js', included: false},
-  {pattern: 'test/**/*Spec.js', included: false},
-
-  'test/test-main.js',
-];
+        'test/test-main.js',
+    ],
 
 
-// list of files to exclude
-exclude = [
-    'src/main.js'
-];
+    // list of files to exclude
+    exclude: [
+        'src/main.js'
+    ],
 
 
-// test results reporter to use
-// possible values: 'dots', 'progress', 'junit'
-reporters = ['progress'];
+    // test results reporter to use
+    // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
+    reporters: ['progress'],
 
 
-// web server port
-port = 9876;
+    // web server port
+    port: 9876,
 
 
-// cli runner port
-runnerPort = 9100;
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
 
 
-// enable / disable colors in the output (reporters and logs)
-colors = true;
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
 
 
-// level of logging
-// possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-logLevel = LOG_INFO;
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
 
 
-// enable / disable watching file and executing tests whenever any file changes
-autoWatch = true;
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera
+    // - Safari (only Mac)
+    // - PhantomJS
+    // - IE (only Windows)
+    browsers: ['Chrome'],
 
 
-// Start these browsers, currently available:
-// - Chrome
-// - ChromeCanary
-// - Firefox
-// - Opera
-// - Safari (only Mac)
-// - PhantomJS
-// - IE (only Windows)
-browsers = ['Chrome'];
+    // If browser does not capture in given timeout [ms], kill it
+    captureTimeout: 60000,
 
 
-// If browser does not capture in given timeout [ms], kill it
-captureTimeout = 60000;
-
-
-// Continuous Integration mode
-// if true, it capture browsers, run tests and exit
-singleRun = false;
+    // Continuous Integration mode
+    // if true, it capture browsers, run tests and exit
+    singleRun: false
+  });
+};


### PR DESCRIPTION
I checked the documentation at http://karma-runner.github.io/0.10/plus/requirejs.html and cloned the example but karma complained about an old configuration. I ran karma init, built a new one and included all the configuration. Now it works again.

Can you merge this to keep the karma documentation up to date?
