### PR TITLE
adds a package.json for the necessary required modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "karma": "~0.12.16",
+    "karma-chrome-launcher": "~0.1.4",
+    "karma-jasmine": "~0.1.5",
+    "karma-requirejs": "~0.2.2",
+    "requirejs": "~2.1.11"
+  }
+}


### PR DESCRIPTION
If you run karma start, it wont work because the necessary dependencies aren't included. I put them in the package.json so someone can just run 'npm install' and then karma start and everything should just work without them having to figure out what are the missing modules.
